### PR TITLE
Reporting structure

### DIFF
--- a/CodeChallenge.Tests.Unit/CodeChallenge.Tests.Unit.csproj
+++ b/CodeChallenge.Tests.Unit/CodeChallenge.Tests.Unit.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CodeChallenge\CodeChallenge.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/CodeChallenge.Tests.Unit/ReportingStructureServiceTests.cs
+++ b/CodeChallenge.Tests.Unit/ReportingStructureServiceTests.cs
@@ -1,0 +1,81 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using CodeChallenge.Services;
+using CodeChallenge.Models;
+using Moq;
+
+namespace CodeChallenge.Tests;
+
+[TestClass]
+public class ReportingStructureServiceTests
+{
+    [TestMethod]
+    public void GetByEmployee_ReturnsNull_WhenIdIsNull()
+    {
+        // Arrange
+        var mockEmployeeService = new Mock<IEmployeeService>();
+        var reportingStructureService = new ReportingStructureService(mockEmployeeService.Object);
+
+        // Act
+        var result = reportingStructureService.GetByEmployee(null);
+
+        // Assert
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public void GetByEmployee_ReturnsNull_WhenEmployeeNotFound()
+    {
+        // Arrange
+        var mockEmployeeService = new Mock<IEmployeeService>();
+        mockEmployeeService.Setup(x => x.GetById(It.IsAny<string>())).Returns<Employee>(null);
+        var reportingStructureService = new ReportingStructureService(mockEmployeeService.Object);
+
+        // Act
+        var result = reportingStructureService.GetByEmployee("nonexistentId");
+
+        // Assert
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public void GetByEmployee_ReturnsReportingStructure_WhenEmployeeFoundWithNoDirectReports()
+    {
+        // Arrange
+        var employee = new Employee { EmployeeId = "id", FirstName = "John", LastName = "Doe", Position = "Manager", Department = "IT", DirectReports = new List<Employee>() };
+        var mockEmployeeService = new Mock<IEmployeeService>();
+        mockEmployeeService.Setup(x => x.GetById("id")).Returns(employee);
+        var reportingStructureService = new ReportingStructureService(mockEmployeeService.Object);
+
+        // Act
+        var result = reportingStructureService.GetByEmployee("id");
+
+        // Assert
+        Assert.AreEqual(employee, result.Employee);
+        Assert.AreEqual(0, result.NumberOfReports);
+    }
+
+    [TestMethod]
+    public void GetByEmployee_ReturnsReportingStructure_WhenEmployeeFoundWithDirectReports()
+    {
+        // Arrange
+        var directReports = new List<Employee>
+        {
+            new Employee { EmployeeId = "1", FirstName = "Jane", LastName = "Smith", Position = "Engineer", Department = "IT" },
+            new Employee { EmployeeId = "2", FirstName = "Bob", LastName = "Jones", Position = "Analyst", Department = "Finance" }
+        };
+        var employee = new Employee { EmployeeId = "id", FirstName = "John", LastName = "Doe", Position = "Manager", Department = "IT", DirectReports = directReports };
+
+        var mockEmployeeService = new Mock<IEmployeeService>();
+        mockEmployeeService.Setup(x => x.GetById("id")).Returns(employee);
+        mockEmployeeService.Setup(x => x.GetById("1")).Returns(directReports[0]);
+        mockEmployeeService.Setup(x => x.GetById("2")).Returns(directReports[1]);
+        var reportingStructureService = new ReportingStructureService(mockEmployeeService.Object);
+
+        // Act
+        var result = reportingStructureService.GetByEmployee("id");
+
+        // Assert
+        Assert.AreEqual(employee, result.Employee);
+        Assert.AreEqual(2, result.NumberOfReports); // Direct reports + their direct reports
+    }
+}

--- a/CodeChallenge.Tests/EmployeeControllerTests.cs
+++ b/CodeChallenge.Tests/EmployeeControllerTests.cs
@@ -1,4 +1,3 @@
-
 using System.Net;
 using System.Net.Http;
 using System.Text;

--- a/CodeChallenge.Tests/ReportingStructureControllerTests.cs
+++ b/CodeChallenge.Tests/ReportingStructureControllerTests.cs
@@ -1,0 +1,65 @@
+﻿using System.Net;
+using System.Net.Http;
+using CodeChallenge.Models;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CodeCodeChallenge.Tests.Integration.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using CodeCodeChallenge.Tests.Integration.Extensions;
+
+
+namespace CodeChallenge.Tests.Integration;
+
+[TestClass]
+public class ReportingStructureControllerTests
+{
+    private static HttpClient _httpClient;
+    private static TestServer _testServer;
+
+    [ClassInitialize]
+    // Attribute ClassInitialize requires this signature
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "<Pending>")]
+    public static void InitializeClass(TestContext context)
+    {
+        _testServer = new TestServer();
+        _httpClient = _testServer.NewClient();
+    }
+
+    [ClassCleanup]
+    public static void CleanUpTest()
+    {
+        _httpClient.Dispose();
+        _testServer.Dispose();
+    }
+
+    [TestMethod]
+    public void GetReportingStructureByEmployeeId_ReturnsNotFound()
+    {
+        // Arrange
+        var nonExistentEmployee = "notARealId";
+
+        // Execute
+        var getRequestTask = _httpClient.GetAsync($"api/reportingStructure/{nonExistentEmployee}");
+        var response = getRequestTask.Result;
+
+        // Assert
+        Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [TestMethod]
+    public void GetReportStructureByEmployeeId_ReturnsReportingStructure_WhenEmployeeFound()
+    {
+        // Arrange
+        var employeeId = "16a596ae-edd3-4847-99fe-c4518e82c86f";
+
+        // Act
+        var getRequestTask = _httpClient.GetAsync($"/api/reportingStructure/{employeeId}");
+        var response = getRequestTask.Result;
+
+        // Assert
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        var reportingStructure = response.DeserializeContent<ReportingStructure>();
+        Assert.IsNotNull(reportingStructure);
+        Assert.AreEqual(4, reportingStructure.NumberOfReports);
+    }
+}

--- a/CodeChallenge.sln
+++ b/CodeChallenge.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CodeChallenge", "CodeChalle
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CodeChallenge.Tests.Integration", "CodeChallenge.Tests\CodeChallenge.Tests.Integration.csproj", "{0EFCF139-7A42-4E38-B638-856076B0108A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeChallenge.Tests.Unit", "CodeChallenge.Tests.Unit\CodeChallenge.Tests.Unit.csproj", "{DD199F00-4156-478F-BE78-D35B222DF255}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{0EFCF139-7A42-4E38-B638-856076B0108A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0EFCF139-7A42-4E38-B638-856076B0108A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0EFCF139-7A42-4E38-B638-856076B0108A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DD199F00-4156-478F-BE78-D35B222DF255}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DD199F00-4156-478F-BE78-D35B222DF255}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DD199F00-4156-478F-BE78-D35B222DF255}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DD199F00-4156-478F-BE78-D35B222DF255}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CodeChallenge/Config/App.cs
+++ b/CodeChallenge/Config/App.cs
@@ -44,6 +44,7 @@ namespace CodeChallenge.Config
 
             services.AddScoped<IEmployeeService, EmployeeService>();
             services.AddScoped<IEmployeeRepository, EmployeeRespository>();
+            services.AddScoped<IReportingStructureService, ReportingStructureService>();
 
             services.AddControllers();
         }

--- a/CodeChallenge/Config/App.cs
+++ b/CodeChallenge/Config/App.cs
@@ -45,6 +45,8 @@ namespace CodeChallenge.Config
             services.AddScoped<IEmployeeService, EmployeeService>();
             services.AddScoped<IEmployeeRepository, EmployeeRespository>();
             services.AddScoped<IReportingStructureService, ReportingStructureService>();
+            services.AddScoped<ICompensationService, CompensationService>();
+            services.AddScoped<ICompensationRepository, CompensationRepository>();
 
             services.AddControllers();
         }

--- a/CodeChallenge/Controllers/CompensationController.cs
+++ b/CodeChallenge/Controllers/CompensationController.cs
@@ -1,0 +1,52 @@
+﻿using CodeChallenge.Models;
+using CodeChallenge.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace CodeChallenge.Controllers
+{
+    [ApiController]
+    [Route("api/compensation")]
+    public class CompensationController : ControllerBase
+    {
+        private readonly ILogger _logger;
+        private readonly ICompensationService _compensationService;
+
+        public CompensationController(ILogger<CompensationController> logger, ICompensationService compensationService)
+        {
+            _logger = logger;
+            _compensationService = compensationService;
+        }
+
+        [HttpPost]
+        public IActionResult CreateCompensation([FromBody] Compensation compensation)
+        {
+            //This first check would likely be split into a few different checks so that better text could be sent back to 
+            //the client
+            if(compensation == null || string.IsNullOrEmpty(compensation.EmployeeId))
+                return BadRequest();
+            if (compensation.Salary <= 0)
+                return BadRequest("Salary must be a positive decimal value");
+
+            _logger.LogDebug($"Received compensation create request for employeeId'{compensation.EmployeeId}'");
+
+            var createdCompensation = _compensationService.Create(compensation);
+
+            //I'm not familiar with what CreatedAtRoute does (outside of returning a 201), I'm following the pattern from CreateEmployee
+            return CreatedAtRoute("getCompensationByEmployeeId", new { employeeId = createdCompensation.EmployeeId }, createdCompensation);
+        }
+
+        [HttpGet("{employeeId}", Name = "getCompensationByEmployeeId")]
+        public IActionResult GetCompensationByEmployeeId(string employeeId)
+        {
+            _logger.LogDebug($"Received compensation get request for '{employeeId}'");
+
+            var compensation = _compensationService.GetByEmployeeId(employeeId);
+
+            if(compensation == null)
+                return NotFound();
+
+            return Ok(compensation);
+        }
+    }
+}

--- a/CodeChallenge/Controllers/ReportingStructureController.cs
+++ b/CodeChallenge/Controllers/ReportingStructureController.cs
@@ -1,6 +1,7 @@
 ﻿using CodeChallenge.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using System;
 
 namespace CodeChallenge.Controllers;
 
@@ -11,17 +12,20 @@ public class ReportingStructureController : ControllerBase
     private readonly ILogger _logger;
     private readonly IReportingStructureService _reportingStructureService;
 
-    [HttpGet("{id}", Name = "getReportStructure")]
-    public IActionResult GetReportStructureByEmployeeId(string id)
+    public ReportingStructureController(IReportingStructureService reportingStructureService, ILogger<ReportingStructureController> logger)
     {
-        if (string.IsNullOrEmpty(id))
-            return BadRequest();
+        _reportingStructureService = reportingStructureService;
+        _logger = logger;
+    }
 
+    [HttpGet("{id}", Name = "getReportingStructure")]
+    public IActionResult GetReportingStructureByEmployeeId(String id)
+    {
         _logger.LogDebug($"Received reporting structure request for id: '{id}'");
 
         var reportingStructure = _reportingStructureService.GetByEmployee(id);
         if(reportingStructure == null)
-            return BadRequest();
+            return NotFound();
 
         return Ok(reportingStructure);
     }

--- a/CodeChallenge/Controllers/ReportingStructureController.cs
+++ b/CodeChallenge/Controllers/ReportingStructureController.cs
@@ -1,0 +1,28 @@
+﻿using CodeChallenge.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace CodeChallenge.Controllers;
+
+[ApiController]
+[Route("api/reportingStructure")]
+public class ReportingStructureController : ControllerBase
+{
+    private readonly ILogger _logger;
+    private readonly IReportingStructureService _reportingStructureService;
+
+    [HttpGet("{id}", Name = "getReportStructure")]
+    public IActionResult GetReportStructureByEmployeeId(string id)
+    {
+        if (string.IsNullOrEmpty(id))
+            return BadRequest();
+
+        _logger.LogDebug($"Received reporting structure request for id: '{id}'");
+
+        var reportingStructure = _reportingStructureService.GetByEmployee(id);
+        if(reportingStructure == null)
+            return BadRequest();
+
+        return Ok(reportingStructure);
+    }
+}

--- a/CodeChallenge/Data/EmployeeContext.cs
+++ b/CodeChallenge/Data/EmployeeContext.cs
@@ -15,5 +15,7 @@ namespace CodeChallenge.Data
         }
 
         public DbSet<Employee> Employees { get; set; }
+
+        public DbSet<Compensation> Compensation { get; set; }
     }
 }

--- a/CodeChallenge/Models/Compensation.cs
+++ b/CodeChallenge/Models/Compensation.cs
@@ -4,7 +4,6 @@ namespace CodeChallenge.Models;
 
 public class Compensation
 {
-    //removing this because it's easier to test than having to pass a fully formed Employee 
     public Employee Employee { get; set; }
 
     public decimal Salary { get; set; }

--- a/CodeChallenge/Models/Compensation.cs
+++ b/CodeChallenge/Models/Compensation.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace CodeChallenge.Models;
+
+public class Compensation
+{
+    //removing this because it's easier to test than having to pass a fully formed Employee 
+    public Employee Employee { get; set; }
+
+    public decimal Salary { get; set; }
+
+    public DateTime EffectiveDate { get; set; }
+
+    public string EmployeeId { get; set; }
+
+    public string Id { get; set; }
+}

--- a/CodeChallenge/Models/Employee.cs
+++ b/CodeChallenge/Models/Employee.cs
@@ -12,6 +12,6 @@ namespace CodeChallenge.Models
         public String LastName { get; set; }
         public String Position { get; set; }
         public String Department { get; set; }
-        public List<Employee> DirectReports { get; set; }
+        public List<Employee> DirectReports { get; set; } = new List<Employee>();
     }
 }

--- a/CodeChallenge/Models/Employee.cs
+++ b/CodeChallenge/Models/Employee.cs
@@ -12,6 +12,7 @@ namespace CodeChallenge.Models
         public String LastName { get; set; }
         public String Position { get; set; }
         public String Department { get; set; }
+        //added the instantiation so that an employee's DirectReports are never null
         public List<Employee> DirectReports { get; set; } = new List<Employee>();
     }
 }

--- a/CodeChallenge/Models/ReportingStructure.cs
+++ b/CodeChallenge/Models/ReportingStructure.cs
@@ -1,0 +1,8 @@
+﻿namespace CodeChallenge.Models;
+
+public class ReportingStructure
+{
+    public Employee Employee { get; set; }
+
+    public int NumberOfReports { get; set; }
+}

--- a/CodeChallenge/Repositories/CompensationRepository.cs
+++ b/CodeChallenge/Repositories/CompensationRepository.cs
@@ -28,7 +28,13 @@ namespace CodeChallenge.Repositories
 
         public Compensation GetByEmployeeId(string employeeId)
         {
-            var compensation = _employeeContext.Compensation.SingleOrDefault(c => c.EmployeeId == employeeId);
+            var compensation = _employeeContext.Compensation
+                // This Include may be necessary depending on the requirements of the endpoint. We already have an Employee Controller
+                // so it probably isn't necessary to return both of these things at the same time. I suppose it will
+                // depend on the context of why the endpoint is being built/what it's being used for
+                .Include(c => c.Employee)
+                .ThenInclude(e => e.DirectReports)
+                .SingleOrDefault(c => c.EmployeeId == employeeId);
 
             return compensation;
         }

--- a/CodeChallenge/Repositories/CompensationRepository.cs
+++ b/CodeChallenge/Repositories/CompensationRepository.cs
@@ -1,0 +1,41 @@
+﻿using CodeChallenge.Data;
+using CodeChallenge.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CodeChallenge.Repositories
+{
+    public class CompensationRepository : ICompensationRepository
+    {
+        private readonly EmployeeContext _employeeContext;
+        private readonly ILogger<IEmployeeRepository> _logger;
+
+        public CompensationRepository(EmployeeContext employeeContext, ILogger<IEmployeeRepository> logger)
+        {
+            _employeeContext = employeeContext;
+            _logger = logger;
+        }
+
+        public Compensation Add(Compensation compensation)
+        {
+            compensation.Id = Guid.NewGuid().ToString();
+            _employeeContext.Compensation.Add(compensation);
+            return compensation;
+        }
+
+        public Compensation GetByEmployeeId(string employeeId)
+        {
+            var compensation = _employeeContext.Compensation.SingleOrDefault(c => c.EmployeeId == employeeId);
+
+            return compensation;
+        }
+
+        public Task SaveAsync()
+        {
+            return _employeeContext.SaveChangesAsync();
+        }
+    }
+}

--- a/CodeChallenge/Repositories/EmployeeRespository.cs
+++ b/CodeChallenge/Repositories/EmployeeRespository.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using CodeChallenge.Models;
@@ -29,14 +28,10 @@ namespace CodeChallenge.Repositories
 
         public Employee GetById(string id)
         {
-            // I was consistently encountering one of the weirdest bugs I've ever seen
-            // For some reason, the Employee.directReports list wouldn't materialize into the employee variable unless I breakpointed on that line
-            // and then expanded the enumerable in Visual Studio...truly bizarre
-            // Of course, I would never do _employeeContext.Employees.ToList() in an actual codebase (as it would materialize that entire table into memory), but was necessary to work around that odd bug
-            // This was something that I tested on the master branch as well, and was a problem with the way the code was originally written
-            var employees = _employeeContext.Employees.ToList();
+            // This tripped me up! Because the Employee contains a self-join to a list of Employees, it needed to
+            // be told to include them. I'm familiar with eager loading, the self-join just tripped me up.
+            var employee = _employeeContext.Employees.Include(e => e.DirectReports).SingleOrDefault(e => e.EmployeeId == id);
 
-            var employee = employees.SingleOrDefault(e => e.EmployeeId == id);
             return employee;
         }
 

--- a/CodeChallenge/Repositories/EmployeeRespository.cs
+++ b/CodeChallenge/Repositories/EmployeeRespository.cs
@@ -29,7 +29,15 @@ namespace CodeChallenge.Repositories
 
         public Employee GetById(string id)
         {
-            return _employeeContext.Employees.SingleOrDefault(e => e.EmployeeId == id);
+            // I was consistently encountering one of the weirdest bugs I've ever seen
+            // For some reason, the Employee.directReports list wouldn't materialize into the employee variable unless I breakpointed on that line
+            // and then expanded the enumerable in Visual Studio...truly bizarre
+            // Of course, I would never do _employeeContext.Employees.ToList() in an actual codebase (as it would materialize that entire table into memory), but was necessary to work around that odd bug
+            // This was something that I tested on the master branch as well, and was a problem with the way the code was originally written
+            var employees = _employeeContext.Employees.ToList();
+
+            var employee = employees.SingleOrDefault(e => e.EmployeeId == id);
+            return employee;
         }
 
         public Task SaveAsync()

--- a/CodeChallenge/Repositories/ICompensationRepository.cs
+++ b/CodeChallenge/Repositories/ICompensationRepository.cs
@@ -1,0 +1,13 @@
+﻿using CodeChallenge.Models;
+using System.Threading.Tasks;
+
+namespace CodeChallenge.Repositories
+{
+    public interface ICompensationRepository
+    {
+        Compensation Add(Compensation compensation);
+        Compensation GetByEmployeeId(string employeeId);
+        Task SaveAsync();
+
+    }
+}

--- a/CodeChallenge/Services/CompensationService.cs
+++ b/CodeChallenge/Services/CompensationService.cs
@@ -1,0 +1,34 @@
+﻿using CodeChallenge.Models;
+using CodeChallenge.Repositories;
+
+namespace CodeChallenge.Services
+{
+    public class CompensationService : ICompensationService
+    {
+        private readonly ICompensationRepository _compensationRepository;
+
+        public CompensationService(ICompensationRepository compensationRepository)
+        {
+            _compensationRepository = compensationRepository;
+        }
+
+        public Compensation Create(Compensation compensation)
+        {
+            if(compensation != null)
+            {
+                _compensationRepository.Add(compensation);
+                _compensationRepository.SaveAsync().Wait();
+            }
+
+            return compensation;
+        }
+
+        public Compensation GetByEmployeeId(string employeeId)
+        {
+            if(string.IsNullOrWhiteSpace(employeeId))
+                return null;
+
+            return _compensationRepository.GetByEmployeeId(employeeId);
+        }
+    }
+}

--- a/CodeChallenge/Services/ICompensationService.cs
+++ b/CodeChallenge/Services/ICompensationService.cs
@@ -1,0 +1,9 @@
+﻿using CodeChallenge.Models;
+
+namespace CodeChallenge.Services;
+
+public interface ICompensationService
+{
+    Compensation Create(Compensation compensation);
+    Compensation GetByEmployeeId(string employeeId);
+}

--- a/CodeChallenge/Services/IReportingStructureService.cs
+++ b/CodeChallenge/Services/IReportingStructureService.cs
@@ -1,0 +1,8 @@
+﻿using CodeChallenge.Models;
+
+namespace CodeChallenge.Services;
+
+public interface IReportingStructureService
+{
+    ReportingStructure GetByEmployee(string id);
+}

--- a/CodeChallenge/Services/IReportingStructureService.cs
+++ b/CodeChallenge/Services/IReportingStructureService.cs
@@ -1,4 +1,5 @@
 ﻿using CodeChallenge.Models;
+using System.Threading.Tasks;
 
 namespace CodeChallenge.Services;
 

--- a/CodeChallenge/Services/ReportingStructureService.cs
+++ b/CodeChallenge/Services/ReportingStructureService.cs
@@ -1,0 +1,36 @@
+﻿using CodeChallenge.Models;
+
+namespace CodeChallenge.Services;
+
+public class ReportingStructureService : IReportingStructureService
+{
+    private readonly IEmployeeService _employeeService;
+
+    public ReportingStructureService(IEmployeeService employeeService)
+    {
+        _employeeService = employeeService;
+    }
+
+    public ReportingStructure GetByEmployee(string id)
+    {
+        if (id == null)
+            return null;
+
+        var employee = _employeeService.GetById(id);
+        if (employee == null)
+            return null;
+
+        var directReports = employee.DirectReports.Count;
+
+        foreach(var directReport in employee.DirectReports)
+        {
+            // For the purposes of a coding challenge, this is how I would leave this. I would **NOT** leave this in actual prod code though.
+            // This could absolutely crush a database as we go to retrieve employees one-by-one to determine their direct reports (across multiple requests, across multiple clients, etc.)
+            // Paychex is almost a Fortune 500 company, so I think it's safe to say that this could be a costly request to be making. Ideally, this would 
+            // be a stored procedure so that the responsibility of finding an employee and all their direct reports is pushed off to the database.
+            directReports += _employeeService.GetById(directReport.EmployeeId).DirectReports.Count;
+        }
+
+        return new ReportingStructure { Employee = employee, NumberOfReports = directReports };
+    }
+}

--- a/CodeChallenge/Services/ReportingStructureService.cs
+++ b/CodeChallenge/Services/ReportingStructureService.cs
@@ -26,8 +26,8 @@ public class ReportingStructureService : IReportingStructureService
         {
             // For the purposes of a coding challenge, this is how I would leave this. I would **NOT** leave this in actual prod code though.
             // This could absolutely crush a database as we go to retrieve employees one-by-one to determine their direct reports (across multiple requests, across multiple clients, etc.)
-            // Paychex is almost a Fortune 500 company, so I think it's safe to say that this could be a costly request to be making. Ideally, this would 
-            // be a stored procedure so that the responsibility of finding an employee and all their direct reports is pushed off to the database.
+            // Paychex is almost a Fortune 500 company, likely has clients of all sizes, so I think it's safe to say that this could be a costly request to be making. Ideally, this would 
+            // be a stored procedure so that the responsibility of finding an employee and all their direct reports is pushed off to the database
             directReports += _employeeService.GetById(directReport.EmployeeId).DirectReports.Count;
         }
 


### PR DESCRIPTION
Making a PR just so I can show my progress through these changes (didn't realize I was committing through my work account...woops!)

Overall, this probably took me about 4 hours. It took me a little while to get used to the structure. I'm not used to such strict adherence of the Clean Code  Architecture (controller -> service -> repository). At least named repositories. I usually just encapsulate Entity Framework Core calls directly in the service layer. We also tend to keep our controllers as thin as possible, and inject either services that already contain the code we need, or the dbContext when we need to retrieve data from the database. 

But, I actually like this structure. I like the flexibility of the controllers to emit different status codes, even if it means injecting a few more dependencies to be able to handle those different scenarios.  It also keeps things fairly thin and dispersed as you go down through the layers. I could see this possibly reducing services that are just a wall of dependencies followed by hundreds of lines of code.

One of the things I struggled with early on was deciding whether or not to inject a service within another service (line 19 in the ReportingStructureService). I could see someone making an argument that DRY isn't important here, and you may want to have separate business logic from the EmployeeService.GetById() function (maybe that service needs to include deleted employees, but ReportingStructureService doesn't and vice versa), so I'd be curious to hear your thoughts about that.

There are a few other things I wanted to mention:

1. Since this is simply a coding challenge, Line 31 in the ReportingStructureService is just doing the C# way of recursion. I almost certainly would NOT do this in an actual prod environment (doubly so for a company with as many clients as Paychex). You'd be hammering the database to get employees one at a time. Ideally, a stored procedure would be written to handle that recursion, and have the employee as well as their direct reports returned all at once.
2. I would also consider adding DTOs for use in the Compensation controller/service/repository. That could possibly contain sensitive information and, even outside of that, you may not need to return all employee info along with their salary info at the same time.
3. There would definitely be tests for both all of the code relating to Compensation (again, just a coding challenge and I proved that I know how to write worthwhile tests for the ReportingStructure controller/service)
4. I'd also probably do some cleanup of the using statements in some of the files since some of them are no longer being used
5. Getting ticky-tacky here, but would also likely change String references to just the string alias

I'm unfamiliar with CreatedAtRoute. I understand that it's returning a 201, but I'm not sure what the rest of it's doing. It seems to be somehow coupling itself to the HttpGet that's created later in the Employee and Compensation controllers? I added it in the Compensation controller simply to follow the pattern.